### PR TITLE
Handle errors

### DIFF
--- a/lib/Reprepro/Uploaders.pm
+++ b/lib/Reprepro/Uploaders.pm
@@ -78,6 +78,7 @@ sub check_package {
    my $key_path = "/files/$self->{uploaders}/allow[$key_condition]";
 
    $self->{package} = $package;
+   @{$self->{errors}} = [];
 
    foreach my $allow ($self->{aug}->match($key_path)) {
       return 1 if ($self->check_allow($allow));
@@ -165,6 +166,7 @@ sub check_source {
       return 1;
    } else {
       print "V: Check $field with $value=$source failed",$/ if $self->{verbose};
+      push @{$self->{errors}}, "Check $field with $value=$source failed";
       return 0;
    }
 }
@@ -198,6 +200,7 @@ sub check_items {
             next ITEM;
          } else {
             print "V: Check $field with $value=$item failed",$/ if $self->{verbose};
+            push @{$self->{errors}}, "Check $field with $value=$item failed";
          }
       }
    }

--- a/t/02-run-examples.t
+++ b/t/02-run-examples.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-use Test::More tests => 9;
+use Test::More tests => 13;
 use Reprepro::Uploaders;
 
 my $uploaders = Reprepro::Uploaders->new(
@@ -46,7 +46,9 @@ $test_package{key} = "12AB34CD";
 $perl_package{key} = "12AB34CD";
 $bin_package{key}  = "12AB34CD";
 is($uploaders->check_package(\%test_package), 0, "Autobuilders uploads only binaries");
+is($#{$uploaders->{errors}}, 6, "6 errors found");
 is($uploaders->check_package(\%perl_package), 0, "Autobuilders uploads only binaries");
+is($#{$uploaders->{errors}}, 3, "3 errors found");
 is($uploaders->check_package(\%bin_package), 1, "Autobuilders uploads only binaries");
 
 
@@ -54,6 +56,8 @@ $test_package{key} = "ABCD1234";
 $perl_package{key} = "ABCD1234";
 $bin_package{key}  = "ABCD1234";
 is($uploaders->check_package(\%test_package), 0, "Perl dev uploads specific packages");
+is($#{$uploaders->{errors}}, 3, "3 errors found");
 is($uploaders->check_package(\%perl_package), 1, "Perl dev uploads specific packages");
 is($uploaders->check_package(\%bin_package), 0, "Perl dev uploads specific packages");
+is($#{$uploaders->{errors}}, 3, "3 errors found");
 


### PR DESCRIPTION
Hi,

here is the patch so users can now get info about which test has failed...

Errors can be accessed by consulting the array $uploaders->{errors}
